### PR TITLE
use http url instead of ssh for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "typed_racket_benchmarks"]
 	path = typed_racket_benchmarks
-	url = git@github.com:Gradual-Typing/gtp-benchmarks.git
+	url = https://github.com/Gradual-Typing/gtp-benchmarks.git


### PR DESCRIPTION
This allows us to checkout the repo without ssh credentials.